### PR TITLE
feat(homepage): add about section with bio and resume download

### DIFF
--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -33,6 +33,19 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the about section", () => {
+    render(<HomePage />);
+    expect(screen.getByRole("heading", { name: "About", level: 2 })).toBeInTheDocument();
+  });
+
+  it("renders the resume download link", () => {
+    render(<HomePage />);
+    expect(screen.getByRole("link", { name: /download resume/i })).toHaveAttribute(
+      "href",
+      "/resume.pdf"
+    );
+  });
+
   it("renders the projects section", () => {
     render(<HomePage />);
     expect(screen.getByRole("heading", { name: "Projects", level: 2 })).toBeInTheDocument();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Owen W — Projects",
+  title: "Owen W | Projects",
   description: "Personal homepage and project showcase.",
 };
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 /**
- * 404 page — shown for any route that doesn't exist.
+ * 404 page, shown for any route that doesn't exist.
  */
 export default function NotFound() {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Mail } from "lucide-react";
+import { Download, ExternalLink, Mail } from "lucide-react";
 
 import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { ProjectCard } from "@/components/ProjectCard";
@@ -75,8 +75,39 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* Projects — surface tint to break up the background */}
-        <section aria-labelledby="projects-heading" className="bg-surface/60 py-24">
+        {/* About + Resume */}
+        <section aria-labelledby="about-heading" className="bg-surface/60 py-24">
+          <div className="mx-auto max-w-5xl px-6">
+            <h2
+              id="about-heading"
+              className="font-heading text-3xl font-semibold text-text-primary"
+            >
+              About
+            </h2>
+            <div className="mt-6 max-w-2xl space-y-4 text-lg leading-relaxed text-text-muted">
+              <p>
+                I&apos;m a software engineer who enjoys building things end-to-end — writing the
+                schema, standing up the API, and sweating the UI details. I care about code that is
+                easy to read, systems that are easy to reason about, and products that are actually
+                pleasant to use.
+              </p>
+              <p>
+                Outside of work I&apos;m usually watching films, planning the next trip, or
+                tinkering with a side project that probably won&apos;t ship. This site is one of the
+                ones that did.
+              </p>
+            </div>
+            <div className="mt-8">
+              <ButtonLink href="/resume.pdf" download size="sm">
+                <Download className="mr-1.5 h-4 w-4" />
+                Download resume
+              </ButtonLink>
+            </div>
+          </div>
+        </section>
+
+        {/* Projects */}
+        <section aria-labelledby="projects-heading" className="py-24">
           <div className="mx-auto max-w-5xl px-6">
             <div className="flex items-baseline gap-3">
               <h2

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import type { LetterboxdFilm } from "@/types/letterboxd";
 const films = letterboxdData.films as LetterboxdFilm[];
 
 /**
- * Homepage — hero, projects, infrastructure, recently watched, and contact.
+ * Homepage: hero, projects, infrastructure, recently watched, and contact.
  */
 export default function HomePage() {
   return (
@@ -47,7 +47,7 @@ export default function HomePage() {
               on the web.
             </h1>
             <p className="mt-8 max-w-2xl text-lg leading-relaxed text-text-muted">
-              I like working across the full stack — from database schemas to UI details. Currently
+              I like working across the full stack, from database schemas to UI details. Currently
               building a blog, a travel map, and whatever else seems interesting.
             </p>
             <div className="mt-10 flex flex-wrap gap-3">
@@ -86,7 +86,7 @@ export default function HomePage() {
             </h2>
             <div className="mt-6 max-w-2xl space-y-4 text-lg leading-relaxed text-text-muted">
               <p>
-                I&apos;m a software engineer who enjoys building things end-to-end — writing the
+                I&apos;m a software engineer who enjoys building things end-to-end: writing the
                 schema, standing up the API, and sweating the UI details. I care about code that is
                 easy to read, systems that are easy to reason about, and products that are actually
                 pleasant to use.
@@ -207,7 +207,7 @@ export default function HomePage() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="group flex flex-col gap-2"
-                    aria-label={`${film.title} (${film.year}) — ${formatRating(film.rating)}`}
+                    aria-label={`${film.title} (${film.year}), ${formatRating(film.rating)}`}
                   >
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
@@ -235,7 +235,7 @@ export default function HomePage() {
               Say hello
             </h2>
             <p className="mt-4 max-w-lg text-lg leading-relaxed text-text-muted">
-              Questions, ideas, or just want to say hi — my inbox is open.
+              Questions, ideas, or just want to say hi. My inbox is open.
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <ButtonLink href="mailto:owenw2k@gmail.com" size="sm">


### PR DESCRIPTION
## What changed
- New About section between hero and projects: two-paragraph bio and a Download resume button
- Resume served from `/public/resume.pdf` (drop the file there to activate the button)
- Em dashes removed from all copy and comments across the codebase

## Unit test results
All 32 tests pass (2 new: about heading, resume link).

## Playwright test results
N/A

## Screenshots
TBD on Vercel preview

## Checklist
- [x] Tests pass
- [x] No hardcoded secrets
- [x] Follows conventions in CLAUDE.md