### PR TITLE
refactor(tests): eliminate static data and hardcoded copy from test assertions

### DIFF
--- a/__tests__/components/ProjectCard.test.tsx
+++ b/__tests__/components/ProjectCard.test.tsx
@@ -6,30 +6,27 @@ import { createProjectCard } from "../factories/createProjectCard";
 
 describe("ProjectCard", () => {
   it("renders the project name and description", () => {
-    const card = createProjectCard({ name: "Blog", description: "My personal blog." });
+    const card = createProjectCard();
     render(<ProjectCard {...card} />);
 
-    expect(screen.getByRole("heading", { name: "Blog" })).toBeInTheDocument();
-    expect(screen.getByText("My personal blog.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: card.name })).toBeInTheDocument();
+    expect(screen.getByText(card.description)).toBeInTheDocument();
   });
 
   it("renders all tech stack tags", () => {
     const card = createProjectCard({ techStack: ["Next.js", "DynamoDB", "Lambda"] });
     render(<ProjectCard {...card} />);
 
-    expect(screen.getByText("Next.js")).toBeInTheDocument();
-    expect(screen.getByText("DynamoDB")).toBeInTheDocument();
-    expect(screen.getByText("Lambda")).toBeInTheDocument();
+    for (const tag of card.techStack) {
+      expect(screen.getByText(tag)).toBeInTheDocument();
+    }
   });
 
   it("renders the GitHub link", () => {
-    const card = createProjectCard({ githubUrl: "https://github.com/owenw2k/blog" });
+    const card = createProjectCard();
     render(<ProjectCard {...card} />);
 
-    expect(screen.getByRole("link", { name: /github/i })).toHaveAttribute(
-      "href",
-      "https://github.com/owenw2k/blog"
-    );
+    expect(screen.getByRole("link", { name: /github/i })).toHaveAttribute("href", card.githubUrl);
   });
 
   it("renders a stretched card link to liveUrl when provided", () => {
@@ -38,7 +35,7 @@ describe("ProjectCard", () => {
 
     expect(screen.getByRole("link", { name: /open test project/i })).toHaveAttribute(
       "href",
-      "https://example.com"
+      card.liveUrl
     );
   });
 
@@ -55,7 +52,7 @@ describe("ProjectCard", () => {
 
     expect(screen.getByRole("link", { name: /case study/i })).toHaveAttribute(
       "href",
-      "https://blog.example.com/case-study"
+      card.caseStudyUrl
     );
   });
 

--- a/__tests__/page-with-data.test.tsx
+++ b/__tests__/page-with-data.test.tsx
@@ -6,10 +6,10 @@ import { createInfraCard } from "./factories/createInfraCard";
 
 import type { LetterboxdFilm } from "@/types/letterboxd";
 
-// letterboxd.json is read at module level in page.tsx, so the mock must return a plain value —
-// a getter closure would reference module-level variables before they are initialized due to
-// Jest's mock hoisting. Assertions derive the title from jest.requireMock to avoid repeating
-// the literal string.
+// letterboxd.json is read at module level in page.tsx, so the mock must return a plain value,
+// not a getter closure. A getter would reference module-level variables before they are
+// initialized due to Jest's mock hoisting. Assertions derive the title from jest.requireMock
+// to avoid repeating the literal string.
 jest.mock("@/data/letterboxd.json", () => ({
   films: [
     {

--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -2,38 +2,32 @@ import { render, screen } from "@testing-library/react";
 
 import HomePage from "@/app/page";
 
+import { createProjectCard } from "./factories/createProjectCard";
+
+const mockProjects = [createProjectCard(), createProjectCard({ name: "Second Project" })];
+
 jest.mock("next-themes", () => ({
   useTheme: () => ({ theme: "light", setTheme: jest.fn() }),
 }));
 
 jest.mock("@/data/letterboxd.json", () => ({ films: [] }), { virtual: false });
+
 jest.mock("@/data/projects", () => ({
-  projects: [
-    {
-      name: "Blog",
-      description: "Personal blog.",
-      githubUrl: "https://github.com/owenw2k/blog",
-      techStack: ["Next.js"],
-    },
-    {
-      name: "Travel Buddy",
-      description: "Interactive travel map.",
-      githubUrl: "https://github.com/owenw2k/travel-buddy",
-      techStack: ["Next.js"],
-    },
-  ],
+  get projects() {
+    return mockProjects;
+  },
   infraProjects: [],
 }));
 
 describe("HomePage", () => {
-  it("renders the hero heading", () => {
+  it("renders a level-1 heading in the hero", () => {
     render(<HomePage />);
     expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
   });
 
   it("renders the about section", () => {
     render(<HomePage />);
-    expect(screen.getByRole("heading", { name: "About", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /about/i })).toBeInTheDocument();
   });
 
   it("renders the resume download link", () => {
@@ -46,18 +40,19 @@ describe("HomePage", () => {
 
   it("renders the projects section", () => {
     render(<HomePage />);
-    expect(screen.getByRole("heading", { name: "Projects", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /projects/i })).toBeInTheDocument();
   });
 
   it("renders a card for each project", () => {
     render(<HomePage />);
-    expect(screen.getByRole("heading", { name: "Blog", level: 3 })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Travel Buddy", level: 3 })).toBeInTheDocument();
+    for (const project of mockProjects) {
+      expect(screen.getByRole("heading", { name: project.name, level: 3 })).toBeInTheDocument();
+    }
   });
 
   it("renders the contact section", () => {
     render(<HomePage />);
-    expect(screen.getByRole("heading", { name: "Say hello", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /say hello/i })).toBeInTheDocument();
   });
 
   it("renders GitHub and email links in the hero", () => {
@@ -69,7 +64,8 @@ describe("HomePage", () => {
 
   it("renders the recently watched empty state when no films are present", () => {
     render(<HomePage />);
-    expect(screen.getByText("Waiting on the scraper…")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /recently watched/i })).toBeInTheDocument();
+    expect(screen.getByText(/waiting on the scraper/i)).toBeInTheDocument();
   });
 
   it("renders the behind the scenes empty state when no infra projects are present", () => {


### PR DESCRIPTION
## What changed

- Adds \`createInfraCard\` and \`createLetterboxdFilm\` factories so all test data flows through factories
- \`ProjectCard\` tests now derive every assertion from the factory output (\`card.name\`, \`card.liveUrl\`, etc.) — no literal strings repeated between the factory call and the assertion
- \`page.test.tsx\` replaces inline mock objects with \`createProjectCard\`; section presence is asserted via ARIA region roles instead of hardcoded heading text
- \`page-with-data.test.tsx\` replaces inline mock objects with factories; the \`letterboxd.json\` mock uses a plain value (required because \`page.tsx\` reads \`films\` at module level) and assertions derive strings from \`jest.requireMock\` to avoid repeating literals

Implements the new testing rule in global CLAUDE.md: never hardcode UI copy or data literals in test assertions — derive from factory output or \`jest.requireMock\`.

## Checklist
- [x] CI passes (lint, typecheck, unit tests, Playwright)
- [x] Lighthouse score ≥ 90 on all categories
- [x] axe-core reports no violations
- [x] No hardcoded secrets
- [x] Follows conventions in CLAUDE.md