### PR TITLE
chore(ci): add gitleaks secrets scanning and streamline PR template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,3 @@
 _Captured automatically by CI — push a commit to populate._
 
 <!-- screenshots-end -->
-
-## Checklist
-
-- [ ] No secrets committed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What changed
+
+<!-- 1-3 bullet points describing what this PR does and why -->
+
+## Screenshots
+
+<!-- screenshots-start -->
+
+_Captured automatically by CI — push a commit to populate._
+
+<!-- screenshots-end -->
+
+## Checklist
+
+- [ ] No secrets committed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v6
 


### PR DESCRIPTION
## What changed
- Added gitleaks secrets scanning as an early CI step — blocks merge if hardcoded secrets are detected
- Added \`fetch-depth: 0\` to checkout so gitleaks can scan full history
- Created \`.github/pull_request_template.md\` with only genuinely human-verifiable items (CI gates lint, typecheck, tests, Lighthouse, axe-core automatically)

## Screenshots



<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->