### PR TITLE
fix(eslint): remove duplicate @typescript-eslint plugin registration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,3 @@
-import tsPlugin from "@typescript-eslint/eslint-plugin";
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
@@ -8,9 +7,6 @@ const eslintConfig = defineConfig([
   ...nextTs,
   globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts", "coverage/**"]),
   {
-    plugins: {
-      "@typescript-eslint": tsPlugin,
-    },
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/consistent-type-imports": [


### PR DESCRIPTION
## What changed
- Removed the explicit \`@typescript-eslint/eslint-plugin\` import and \`plugins\` block from \`eslint.config.mjs\` — \`eslint-config-next/typescript\` already registers the plugin, so declaring it again causes ESLint 9 to throw "Cannot redefine plugin" whenever the two instances differ (e.g. after a Dependabot version bump)

## Screenshots

Not applicable

<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->