### PR TITLE
fix(card): raise overlay link to z-[1] so image area is clickable

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -31,7 +31,7 @@ export const ProjectCard = ({
         href={liveUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="absolute inset-0 z-0"
+        className="absolute inset-0 z-[1]"
         aria-label={`Open ${name}`}
       />
     )}


### PR DESCRIPTION
## What changed
- The full-card overlay link was `z-0`, which sits below the image div in DOM stacking order — clicks on the screenshot fell through to nothing
- Bumping to `z-[1]` places the invisible link above static-position elements so the whole card (including the image) navigates to the live URL; action buttons remain at `z-10` and work independently

## Screenshots
<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->