### PR TITLE
chore(hub): update blog project tags to Vercel-native stack

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -45,7 +45,7 @@ export const projects: ProjectCard[] = [
     description: "Personal blog with writing on software, design, and building things.",
     liveUrl: "#",
     githubUrl: "https://github.com/owenw2k/blog",
-    techStack: ["Next.js", "Tailwind", "AWS Lambda", "DynamoDB", "MDX"],
+    techStack: ["Next.js", "Tailwind", "Vercel Postgres", "Vercel KV", "MDX"],
   },
   {
     name: "Travel Buddy",


### PR DESCRIPTION
## What changed
- Blog project card tags updated from `AWS Lambda, DynamoDB` to `Vercel Postgres, Vercel KV` to match the architecture migration in blog PR #15

## Screenshots
<!-- screenshots-start -->
_No UI changes in this PR._
<!-- screenshots-end -->